### PR TITLE
Integrations of modifications made for GLGExplainer

### DIFF
--- a/torch_explain/logic/metrics.py
+++ b/torch_explain/logic/metrics.py
@@ -43,6 +43,56 @@ def test_explanation(formula: str, x: torch.Tensor, y: torch.Tensor, target_clas
             # material biconditional: (p<=>q) <=> (p and q) or (not p and not q)
             accuracy = accuracy_score(predictions[mask], y2[mask])
         return accuracy, predictions
+    
+
+def test_explanations(formulas: str, x: torch.Tensor, y: torch.Tensor, mask: torch.Tensor = None,
+                      threshold: float = 0.5, material: bool = False) -> Tuple[float, torch.Tensor]:
+    """
+    Tests alltoghether the logic formulas of different classes.
+    When a sample fires more than one formula, consider the sample wrongly predicted.
+    :param formulas: list of logic formula, one for each class
+    :param x: input data
+    :param y: input labels (MUST be one-hot encoded)
+    :param mask: sample mask
+    :param threshold: threshold to get concept truth values
+    :return: Accuracy of the explanation and predictions
+    """
+    if formulas is None or formulas == []:
+        return 0.0, None
+    for formula in formulas:
+        if formula in ['True', 'False', '']:
+            return 0.0, None  
+    assert len(y.shape) == 2
+    
+    y2 = y.argmax(-1)
+    x = x.cpu().detach().numpy()
+    concept_list = [f"feature{i:03}" for i in range(x.shape[1])]
+    
+    # get predictions using sympy
+    class_predictions = torch.zeros(len(formulas), x.shape[0])
+    for i , formula in enumerate(formulas):
+        explanation = to_dnf(formula)
+        fun = lambdify(concept_list, explanation, 'numpy')
+        
+        predictions = fun(*[x[:, i] > threshold for i in range(x.shape[1])])
+        predictions = torch.LongTensor(predictions)
+        class_predictions[i] = predictions        
+        
+    class_predictions_filtered_by_pred = torch.zeros(class_predictions.shape[1])
+    for i in range(class_predictions.shape[1]):
+        if sum(class_predictions[:, i]) in [0,2]: #todo: vectorize
+            class_predictions_filtered_by_pred[i] = -1 #consider as an error
+        else:
+            class_predictions_filtered_by_pred[i] = class_predictions[:, i].argmax(-1)
+        
+    if material:
+        # material implication: (p=>q) <=> (not p or q)
+        accuracy = torch.sum(torch.logical_or(torch.logical_not(predictions[mask]), y2[mask])) / len(y2[mask])
+        accuracy = accuracy.item()
+    else:
+        # material biconditional: (p<=>q) <=> (p and q) or (not p and not q)
+        accuracy = accuracy_score(class_predictions_filtered_by_pred[mask], y2[mask])
+    return accuracy, class_predictions_filtered_by_pred
 
 
 def complexity(formula: str, to_dnf: bool = False) -> float:

--- a/torch_explain/logic/metrics.py
+++ b/torch_explain/logic/metrics.py
@@ -48,7 +48,7 @@ def test_explanation(formula: str, x: torch.Tensor, y: torch.Tensor, target_clas
 def test_explanations(formulas: str, x: torch.Tensor, y: torch.Tensor, mask: torch.Tensor = None,
                       threshold: float = 0.5, material: bool = False) -> Tuple[float, torch.Tensor]:
     """
-    Tests alltoghether the logic formulas of different classes.
+    Tests all together the logic formulas of different classes.
     When a sample fires more than one formula, consider the sample wrongly predicted.
     :param formulas: list of logic formula, one for each class
     :param x: input data
@@ -66,9 +66,11 @@ def test_explanations(formulas: str, x: torch.Tensor, y: torch.Tensor, mask: tor
     
     y2 = y.argmax(-1)
     x = x.cpu().detach().numpy()
-    concept_list = [f"feature{i:03}" for i in range(x.shape[1])]
+    concept_list = [f"feature{i:010}" for i in range(x.shape[1])]
     
     # get predictions using sympy
+    global class_predictions  # remove
+    global class_predictions_filtered_by_pred
     class_predictions = torch.zeros(len(formulas), x.shape[0])
     for i , formula in enumerate(formulas):
         explanation = to_dnf(formula)
@@ -76,8 +78,8 @@ def test_explanations(formulas: str, x: torch.Tensor, y: torch.Tensor, mask: tor
         
         predictions = fun(*[x[:, i] > threshold for i in range(x.shape[1])])
         predictions = torch.LongTensor(predictions)
-        class_predictions[i] = predictions        
-        
+        class_predictions[i] = predictions          
+    
     class_predictions_filtered_by_pred = torch.zeros(class_predictions.shape[1])
     for i in range(class_predictions.shape[1]):
         if sum(class_predictions[:, i]) in [0,2]: #todo: vectorize

--- a/torch_explain/nn/logic.py
+++ b/torch_explain/nn/logic.py
@@ -12,7 +12,7 @@ class EntropyLinear(nn.Module):
     """
 
     def __init__(self, in_features: int, out_features: int, n_classes: int, temperature: float = 0.6,
-                 bias: bool = True, conceptizator: str = 'identity_bool') -> None:
+                 bias: bool = True, conceptizator: str = 'identity_bool', remove_attention: bool = False) -> None:
         super(EntropyLinear, self).__init__()
         self.in_features = in_features
         self.out_features = out_features
@@ -20,6 +20,7 @@ class EntropyLinear(nn.Module):
         self.temperature = temperature
         self.conceptizator = Conceptizator(conceptizator)
         self.alpha = None
+        self.remove_attention = remove_attention
         self.weight = nn.Parameter(torch.Tensor(n_classes, out_features, in_features))
         if bias:
             self.bias = nn.Parameter(torch.Tensor(n_classes, 1, out_features))
@@ -44,8 +45,12 @@ class EntropyLinear(nn.Module):
 
         # weight the input concepts by awareness scores
         self.alpha_norm = self.alpha / self.alpha.max(dim=1)[0].unsqueeze(1)
-        self.concept_mask = self.alpha_norm > 0.5
-        x = input.multiply(self.alpha_norm.unsqueeze(1))
+        if self.remove_attention:
+            self.concept_mask = torch.ones_like(self.alpha_norm, dtype=torch.bool)
+            x = input
+        else:
+            self.concept_mask = self.alpha_norm > 0.5
+            x = input.multiply(self.alpha_norm.unsqueeze(1))
 
         # compute linear map
         x = x.matmul(self.weight.permute(0, 2, 1)) + self.bias


### PR DESCRIPTION
I'm integrating the modifications made to the package for the development of GLGExplainer, namely:

- `remove_attention` parameter in `EntropyLayer` in order to leave the concept vector unmodified during the forward pass
- function `test_explanations(...)` for computing the accuracy of formulas as a classifier, i.e., considering multiple activations of formulas as an error
- `simplify` parameter in `explain_class(...)` for controlling whether to apply formula simplifications or return a dump of all formulas